### PR TITLE
feat(data): include filename in classNameTemplate for pdf reports

### DIFF
--- a/cfg/jest.config.js
+++ b/cfg/jest.config.js
@@ -128,7 +128,7 @@ module.exports = {
         outputDirectory: './tmp/jest',
         outputName: 'unit.xml',
         suiteNameTemplate: '{filepath}',
-        classNameTemplate: '{classname}',
+        classNameTemplate: '{filename} - {classname}',
         titleTemplate: '{title}',
         ancestorSeparator: ' ',
       },


### PR DESCRIPTION
I'm considering this as an easy way of fulfilling [this request](https://nc1.slack.com/archives/CCNTHJT7V/p1617009988004600) to include filenames in the unit test pdf reports.


Example output:
```
<testsuites name="jest tests" tests="11" failures="0" errors="0" time="1.188">
  <testsuite name="src/util/google.service.test.ts" errors="0" failures="0" skipped="0" timestamp="2024-02-07T10:24:50" time="1.047" tests="5">
    <testcase classname="google.service.test.ts - getOrCreateChangelogDocument" name="should create new file" time="0.006">
    </testcase>
    <testcase classname="google.service.test.ts - getOrCreateChangelogDocument" name="file already exists" time="0.001">
    </testcase>
</testsuites>
```